### PR TITLE
Added note about data model refactoring

### DIFF
--- a/en/teaching.md
+++ b/en/teaching.md
@@ -26,4 +26,4 @@ An extensive collection of literature on the topic [Research Data Management](ht
 
 A master thesis on “Data modeling for Research Data Management Plans” was written by Martin Heger in cooperation with our project.
 [Link to master thesis]({{ site.baseurl }}/docs/Heger_MA.pdf)
-
+(Note: Due to further development of RDMO, the description of the [data model](https://rdmo.readthedocs.io/en/latest/management/domain.html#attributes-entities-and-the-data-model-refactoring) given in this document does no longer represent the current state.)

--- a/lehre.md
+++ b/lehre.md
@@ -26,3 +26,4 @@ An der [Fachhochschule Potsdam (FHP)](http://www.fh-potsdam.de/) wird das Projek
 Es wurde zudem eine umfangreiche Sammlung von [Schriften zum Thema Forschungsdatenmanagement](https://www.zotero.org/groups/forschungsdaten/items) auf Zotero zusammengestellt.
 
 Im Projektkontext hat Martin Heger seine Masterarbeit mit dem Titel "Datenmodellierung für Forschungsdaten-managementpläne" verfasst. [Link zur Masterarbeit]({{ site.baseurl }}/docs/Heger_MA.pdf)
+(Anmerkung: Durch die Weiterentwicklung von RDMO entsprechen einige der hier beschriebenen Informationen zum [Datenmodells](https://rdmo.readthedocs.io/en/latest/management/domain.html#attributes-entities-and-the-data-model-refactoring) nicht mehr dem aktuellen Stand.)

--- a/rdmo_arge.md
+++ b/rdmo_arge.md
@@ -19,7 +19,7 @@ Bereits auf dem letzten RDMO-Community-Treffen im Februar in Potsdam wurde hierf
 **Steuerungsgruppe**
 
 Die RDMO-Arbeitsgemeinschaft wird von einer Steuerungsgruppe (SG) geleitet. Die
-Vertreter*innen der Steuerungsgruppe werden durch die Mitglieder auf der
+Vertreter\*innen der Steuerungsgruppe werden durch die Mitglieder auf der
 Mitgliederversammlung alle drei Jahre oder nach Bedarf neu gewählt.
 Die SG wird die Richtung der Weiterentwicklung begleiten und die
 Abstimmungsprozesse für die Weiterentwicklung der Software und des Content
@@ -29,8 +29,8 @@ koordinieren. Die SG setzt sich aus mindestens fünf Personen zusammen.
 
 Die technische Koordination und Weiterentwicklung von RDMO erfolgt durch eine
 Entwicklungsgruppe (EG). Neben einem Kern von langfristig engagierten
-Entwickler*innen, die die Entwicklung kontinuierlich vorantreiben, ist auch eine
-niedrigschwellige Beteiligung einer größeren Anzahl von Entwickler*innen
+Entwickler\*innen, die die Entwicklung kontinuierlich vorantreiben, ist auch eine
+niedrigschwellige Beteiligung einer größeren Anzahl von Entwickler\*innen
 wünschenswert und möglich. Diese können z. B. projektgebunden zur Entwicklung
 beitragen.
 
@@ -48,7 +48,7 @@ prüfen und ggf. zu verbessern.
 
 Die Mitgliederversammlung der RDMO-Arbeitsgemeinschaft stellt die Gesamtheit aller
 Mitglieder dar. Anwender und weitere Interessenten können an der
-Mitgliederversammlung teilnehmen. Die Mitglieder wählen die Vertreter*innen in der SG.
+Mitgliederversammlung teilnehmen. Die Mitglieder wählen die Vertreter\*innen in der SG.
 Die Mitgliederversammlung tritt je nach Bedarf mindestens aber einmal pro Jahr
 zusammen.
 


### PR DESCRIPTION
This PR addes a note mentioning that some of the information in the master's thesis are outdated. When searching for information about the data model, this is one of the pages that turns up and I was confused to find information contradicting the documentation of RDMO.
This PR adds a link that requires https://github.com/rdmorganiser/rdmo-docs-en/pull/8 to pass in order to work.