### PR TITLE
Add mastodon validation link to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,9 @@
                     <p>
                         <a href="mailto:rdmo-contact@listserv.dfn.de">rdmo-contact@listserv.dfn.de</a>
                     </p>
+                    <p>
+                        <a rel="me" href="https://openbiblio.social/@rdmo">@rdmo@openbiblio.social</a>
+                    </p>
                 </div>
                 <div class="footer-col col-md-4">
                     <h4>Mailingliste</h4>


### PR DESCRIPTION
This PR adds a link to https://openbiblio.social/@rdmo/ to the contact part of the footer, which also proves as validation for mastodon.