### PR TITLE
Vergangene Veranstaltungen dieses Jahres nach unten verschieben

### DIFF
--- a/_data/events/conf.yml
+++ b/_data/events/conf.yml
@@ -1,6 +1,7 @@
 ---
-current_year: y2026
+current_year: ../announcements
 former_years:
+  - y2026
   - y2025
   - y2024
   - y2023


### PR DESCRIPTION
Weil RDMO so erfolgreich ist :sunglasses: , sieht die [Event-Seite](https://rdmorganiser.github.io/Veranstaltungen/) überfüllt aus.

Aus Initiative von @IsabelHohle möchten wir nun alle Veranstaltungen dieses Jahres nach unten verschieben und nur die aktuellen (künftigen) im oberen Bereich belassen.

@jmfrenzel @jhrohrwild @MSpenger Seid ihr mit diesem Vorgehen einverstanden?   
@jochenklar @triole Habe ich den Pfad richtig angegeben? Oder sollen wir lieber die [HTML-Quelldatei](_includes/events.html) anpassen?